### PR TITLE
fix: cmd name and `go mod tidy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,8 @@ go言語を入れてください。
 [公式サイト](https://golang.org/dl/)から落としてください。
 
 ## step 2
-リポジトリをダウンロードして、goを実行します。
-<!-- 僕はgoの初心者なのでソースが汚いです。覚悟してみてください。-->
-
 ```
-$ git clone https://www.github.com/javaboy-github/only-programer-sns-client.git
-$ cd only-programer-sns-client
-$ go run main.go
+go get github.com/javaboy-github/only-programer-sns-client
 ```
 
 `go build main.go`とかすると実行可能ファイルが手に入るらしいです。

--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 # About
+
 [これ](https://qiita.com/HawkClaws/items/599d7666f55e79ef7f56)のクライアントを作りたい。
-# Run
+
+## Run
+
 ## step 1
-go言語を入れてください。
+
+go 言語を入れてください。
+
 ### Arch Linux
 
-```
-# pacman -S go
+```bash
+sudo pacman -S go
 ```
 
 ### その他
+
 <!-- これはひどいw -->
+
 [公式サイト](https://golang.org/dl/)から落としてください。
 
 ## step 2
-```
+
+```bash
 go get github.com/javaboy-github/only-programer-sns-client
 ```
 

--- a/global/global.go
+++ b/global/global.go
@@ -1,0 +1,9 @@
+package global
+
+const (
+	AppName = "opsc"
+	Version = `1.0.2
+Copyright (c) 2021 javaboy-github
+Released under the CC0-1.0 License.
+https://github.com/javaboy-github/only-programer-sns-client`
+)

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,11 @@ module github.com/javaboy-github/only-programer-sns-client
 go 1.16
 
 require (
-	github.com/fatih/color v1.7.0 // indirect
+	github.com/fatih/color v1.7.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/spf13/cobra v0.0.3 // indirect
+	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3 // indirect
+	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 h1:J27LZFQBFoihqXoegpscI10HpjZ7B5WQLLKL2FZXQKw=
+golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var RootCmd = &cobra.Command{
-	Use:   "Programer only SNS client",
+	Use:   "opsc",
 	Short: "Programer only SNS のクライアント。",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("使い方が間違ってます。--helpを見てください。")

--- a/main.go
+++ b/main.go
@@ -2,18 +2,21 @@ package main
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/javaboy-github/only-programer-sns-client/global"
 	"github.com/javaboy-github/only-programer-sns-client/msg"
 	"github.com/javaboy-github/only-programer-sns-client/user"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var RootCmd = &cobra.Command{
-	Use:   "opsc",
-	Short: "Programer only SNS のクライアント。",
+	Use:   global.AppName,
+	Short: global.AppName + ": Programer only SNS のクライアント。",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("使い方が間違ってます。--helpを見てください。")
 	},
+	Version: global.Version,
 }
 
 func main() {

--- a/user/user.go
+++ b/user/user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -46,7 +47,10 @@ func createCmd() *cobra.Command {
 				color.Red("300字を超えています")
 				return
 			}
-			resp, _ := http.Post("https://versatileapi.herokuapp.com/api/user/create_user", "text/plain", strings.NewReader(fmt.Sprintf("{\"name\":\"%s\",\"description\":\"%s\"}", name, profile)))
+			resp, err := http.Post("https://versatileapi.herokuapp.com/api/user/create_user", "text/plain", strings.NewReader(fmt.Sprintf("{\"name\":\"%s\",\"description\":\"%s\"}", name, profile)))
+			if err != nil {
+				log.Fatal(err)
+			}
 			defer resp.Body.Close()
 			fmt.Println("完了しました")
 		},
@@ -58,9 +62,15 @@ func updateUsers() map[string]string {
 	users := map[string]string{}
 	// ユーザー一覧を取得
 	{
-		resp, _ := http.Get("https://versatileapi.herokuapp.com/api/user/all")
+		resp, err := http.Get("https://versatileapi.herokuapp.com/api/user/all")
+		if err != nil {
+			log.Fatal(err)
+		}
 		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
 		io.ReadAll(resp.Body)
 		var result []map[string]string
 		json.Unmarshal([]byte(body), &result)
@@ -70,7 +80,10 @@ func updateUsers() map[string]string {
 	}
 	{
 		// メッセージ一覧からユーザーを追加
-		resp, _ := http.Get("https://versatileapi.herokuapp.com/api/text/all")
+		resp, err := http.Get("https://versatileapi.herokuapp.com/api/text/all")
+		if err != nil {
+			log.Fatal(err)
+		}
 		defer resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
 		io.ReadAll(resp.Body)

--- a/util/util.go
+++ b/util/util.go
@@ -14,19 +14,20 @@ func GetText() string {
 		sc.Scan()
 		input := sc.Text()
 		if input == "" {
-			result = result[:len(result) -1 ]
+			result = result[:len(result)-1]
 			break
 		}
 		result += input + "\n"
 	}
 	return result
 }
+
 // 文字列をjson文字列へエスケープする
 func StringToJsonString(str string) string {
-	str = strings.Replace(str, "\\", "\\\\", -1)// \　-> \\
-	str = strings.Replace(str, "\"", "\\\"", -1)// " -> \"
-	str = strings.Replace(str, "/", "\\/", -1)  // / -> \/
-	str = strings.Replace(str, "\n", "\\n", -1) // <改行> -> \n
-	str = strings.Replace(str, "\t", "\\t", -1) // <タブ> -> \t
+	str = strings.Replace(str, "\\", "\\\\", -1) // \　-> \\
+	str = strings.Replace(str, "\"", "\\\"", -1) // " -> \"
+	str = strings.Replace(str, "/", "\\/", -1)   // / -> \/
+	str = strings.Replace(str, "\n", "\\n", -1)  // <改行> -> \n
+	str = strings.Replace(str, "\t", "\\t", -1)  // <タブ> -> \t
 	return str
 }


### PR DESCRIPTION
- インストール

```bash
$ go get github.com/javaboy-github/only-programer-sns-client
$ opsc -h
```
```txt
opsc: Programer only SNS のクライアント。

Usage:
  opsc [flags]
  opsc [command]

Available Commands:
  help        Help about any command
  msg         メッセージを送信/閲覧/返信します。
  user        ユーザーを登録/更新/閲覧します。

Flags:
  -h, --help      help for opsc
      --version   version for opsc

Use "opsc [command] --help" for more information about a command.
```

```bash
$ opsc --version
```

```txt
opsc version 1.0.2
Copyright (c) 2021 javaboy-github
Released under the CC0-1.0 License.
https://github.com/javaboy-github/only-programer-sns-client
```

- アンインストール

```bash
$ go clean -i github.com/javaboy-github/only-programer-sns-client
$ rm -rf "`which opcs`"
```